### PR TITLE
treats :noconn in mcd

### DIFF
--- a/lib/plug_session_MEMCACHED.ex
+++ b/lib/plug_session_MEMCACHED.ex
@@ -47,6 +47,7 @@ defmodule Plug.Session.MEMCACHED do
         case :mcd.get( table, sid ) do
           {:error, :noproc}   -> raise "cannot find memcached proc"
           {:error, :notfound} -> {nil, %{}}
+          {:error, :noconn} -> {nil, %{}}
           {:ok, data }        -> {sid, data}
         end
     end


### PR DESCRIPTION
I added `{:error, :noconn}` pattern in get/3, because in this situation, :mcd.get/2 returns `{:error, :noconn}`.
- session is saved into the memcached
- memcached restarted
- you get the session with Plug.Session.MEMCACHED.get/3

Since memcached has been restarted, all the data in it gone away. And It's better to be re-connected to memcached than Phoenix crashes.

The exception which occurs in the situation, for example:

```
Request: GET /
(exit) an exception was raised:
(CaseClauseError) no case clause matching: {:error, :noconn}
(plug_session_memcached) lib/plug_session_MEMCACHED.ex:47: Plug.Session.MEMCACHED.get/3
(plug) lib/plug/session.ex:73: anonymous fn/5 in Plug.Session.fetch_session/1
(plug) lib/plug/debugger.ex:145: Plug.Debugger.maybe_fetch_session/1
(plug) lib/plug/debugger.ex:131: Plug.Debugger.render/5
(plug) lib/plug/debugger.ex:118: Plug.Debugger.__catch__/5
(login_study) lib/phoenix/endpoint/render_errors.ex:34: LoginStudy.Endpoint.call/2
(plug) lib/plug/adapters/cowboy/handler.ex:15: Plug.Adapters.Cowboy.Handler.upgrade/4
(cowboy) src/cowboy_protocol.erl:442: :cowboy_protocol.execute/4
```
